### PR TITLE
Extend the app with UDP server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # migrate-svc-test
 
-This repo contains a dummy echo TCP server and client which are used to test
-whether connections are not interrupted during Cilium upgrades.
+This repo contains dummy echo TCP and UDP servers and clients
+that are used to test whether connections are not interrupted 
+during cases such as Cilium upgrades and LB service endpoint updates.
 
 A container image containing both can be fetched from
 [here](https://hub.docker.com/r/cilium/migrate-svc-test).

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,9 @@
 set -e
 set -x
 
-VERSION=${VERSION:-v0.0.2}
+VERSION=${VERSION:-v0.0.3}
+
+export GO111MODULE=auto
 
 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' ./cmd/client
 CGO_ENABLED=0 go build -a -ldflags '-extldflags "-static"' ./cmd/server

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bytes"
-	"crypto/rand"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -18,15 +19,22 @@ func panicOnErr(ctx string, err error) {
 	}
 }
 
-func main() {
-	var (
-		conn net.Conn
-		err  error
-	)
-	addr := os.Args[1]
+type Client interface {
+	Run()
+}
+
+type TCPClient struct {
+	addr string
+	conn net.Conn
+}
+
+func (c TCPClient) Run() {
+	var err error
+	conn := c.conn
+	addr := c.addr
 
 	for i := 0; i < 30; i++ {
-		conn, err = net.Dial("tcp", addr)
+		conn, err = net.Dial("tcp", c.addr)
 		if err == nil {
 			break
 		}
@@ -35,6 +43,7 @@ func main() {
 	}
 	panicOnErr("Failed to connect", err)
 	fmt.Printf("Connected to %s\n", conn.RemoteAddr())
+	defer conn.Close()
 
 	request := make([]byte, MSG_SIZE)
 	reply := make([]byte, MSG_SIZE)
@@ -71,4 +80,97 @@ func main() {
 
 		time.Sleep(500 * time.Millisecond)
 	}
+}
+
+type UDPClient struct {
+	addr string
+	conn *net.UDPConn
+}
+
+func getRequest() []byte {
+	rand.Seed(time.Now().UnixNano())
+	return []byte("ping" + strconv.Itoa(rand.Intn(0xffff)))
+}
+
+func (c UDPClient) Run() {
+	conn := c.conn
+	addr := c.addr
+
+	udpAddr, err := net.ResolveUDPAddr("udp", c.addr)
+	panicOnErr("ResolveUDPAddr", err)
+
+	for i := 0; i < 30; i++ {
+		conn, err = net.DialUDP("udp", nil, udpAddr)
+		if err == nil {
+			break
+		}
+		fmt.Printf("Failed to connect to %s due to %s. Retrying...\n", addr, err)
+		time.Sleep(1 * time.Second)
+	}
+	panicOnErr("Failed to connect", err)
+	fmt.Printf("Connected to %s\n", conn.RemoteAddr())
+
+	// Closes the underlying file descriptor associated with the,
+	// socket so that it no longer refers to any file.
+	defer conn.Close()
+
+	reply := make([]byte, MSG_SIZE)
+
+	for {
+		writeDone := make(chan struct{})
+		request := getRequest()
+		go func() {
+			_, err = conn.Write(request)
+			panicOnErr("conn.Write", err)
+			close(writeDone)
+		}()
+		select {
+		case <-writeDone:
+		case <-time.After(1 * time.Second):
+			panic("conn.Write timed out")
+		}
+
+		readDone := make(chan struct{})
+		n, _, err := conn.ReadFromUDP(reply)
+		panicOnErr("ReadFromUDP", err)
+		close(readDone)
+		select {
+		case <-readDone:
+		case <-time.After(1 * time.Second):
+			panic("conn.Read timed out")
+		}
+		if bytes.Compare(request, reply[:n]) != 0 {
+			panic(fmt.Sprintf("Invalid reply(%v) for request(%v)", reply, request))
+		}
+		fmt.Println("client received: ", string(reply[:n]))
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func main() {
+	addr := os.Args[1]
+	proto := os.Args[2]
+
+	var client Client
+
+	switch proto {
+
+	case "tcp":
+		client = TCPClient{
+			addr: addr,
+		}
+
+	case "udp":
+		client = UDPClient{
+			addr: addr,
+		}
+	default:
+		panic(fmt.Sprintf("unknown protocol %s", proto))
+	}
+
+	for {
+		client.Run()
+	}
+
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,14 +5,71 @@ import (
 	"io"
 	"net"
 	"os"
+	"sync"
+	"time"
 )
 
 const MSG_SIZE = 256 // should be synced with the client
+const WRITE_TIME_OUT = 5 * time.Second
 
 func panicOnErr(ctx string, err error) {
 	if err != nil {
 		panic(fmt.Sprintf("%s: %s", ctx, err))
 	}
+}
+
+type Server interface {
+	Start()
+}
+
+type TCPServer struct {
+	addr string
+}
+
+func (s TCPServer) Start() {
+	listen, err := net.Listen("tcp", s.addr)
+	panicOnErr("net.Listen", err)
+	defer listen.Close()
+
+	fmt.Printf("Listening on %s...\n", s.addr)
+
+	for {
+		conn, err := listen.Accept()
+		panicOnErr("Accept", err)
+		go read(conn)
+	}
+}
+
+type UDPServer struct {
+	addr string
+}
+
+func (s UDPServer) Start() {
+	pc, err := net.ListenPacket("udp", s.addr)
+	panicOnErr("net.Listen", err)
+	fmt.Printf("UDP server listening on %s\n", pc.LocalAddr().String())
+	defer pc.Close()
+
+	wg := sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		for {
+			buf := make([]byte, MSG_SIZE)
+			n, addr, err := pc.ReadFrom(buf)
+			panicOnErr("ReadFrom", err)
+			// fmt.Println("Received ", string(buf[0:n]), " from ", addr)
+
+			deadline := time.Now().Add(WRITE_TIME_OUT)
+			err = pc.SetWriteDeadline(deadline)
+			panicOnErr("SetWriteDeadline", err)
+
+			n, err = pc.WriteTo(buf[:n], addr)
+			panicOnErr("WriteTo", err)
+		}
+	}()
+
+	wg.Wait()
 }
 
 func read(conn net.Conn) {
@@ -28,14 +85,27 @@ func read(conn net.Conn) {
 
 func main() {
 	port := os.Args[1]
-	listen, err := net.Listen("tcp", ":"+port)
-	panicOnErr("net.Listen", err)
+	proto := os.Args[2]
+	addr := ":" + port
 
-	fmt.Printf("Listening on %s...\n", port)
+	var server Server
+
+	switch proto {
+
+	case "tcp":
+		server = TCPServer{
+			addr: addr,
+		}
+
+	case "udp":
+		server = UDPServer{
+			addr: addr,
+		}
+	default:
+		panic(fmt.Sprintf("unknown protocol %s", proto))
+	}
 
 	for {
-		conn, err := listen.Accept()
-		panicOnErr("Accept", err)
-		go read(conn)
+		server.Start()
 	}
 }


### PR DESCRIPTION
We need to test if Cilium datapath keeps existing connections uninterrupted for service endpoint updates.
Ref: https://github.com/cilium/cilium/pull/17312

Also, refactor the code to run UDP or TCP server and client based on the passed argument.